### PR TITLE
Minor cleanup of Vision code and subsystem

### DIFF
--- a/src/main/java/frc/robot/subsystems/Vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/Vision/Vision.java
@@ -129,7 +129,7 @@ public class Vision extends SubsystemBase {
             // update the inputs from the netwrork tables named camNames[i]
             io[i].updateInputs(inputs[i], gyroangle.get().getDegrees());
             // keeps the pipeline always the same
-            io[i].setPipeline(pipeline, camNames[i]);
+            io[i].setPipeline(pipeline);
         }
         swervesGyro = gyroangle.get().getDegrees();
         List<Pose2d> allRobotPoses = new ArrayList<>();

--- a/src/main/java/frc/robot/subsystems/Vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/Vision/Vision.java
@@ -10,8 +10,6 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.VisionConstants;
 import frc.robot.lib.VisionData;
-import frc.robot.lib.util.AllianceFlipUtil;
-import frc.robot.lib.util.LimelightHelpers;
 import frc.robot.Constants.FieldConstants;
 import frc.robot.subsystems.Vision.VisionIO.Pipelines;
 
@@ -22,22 +20,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 import edu.wpi.first.apriltag.AprilTag;
-import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructArrayPublisher;
-import edu.wpi.first.networktables.StructPublisher;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.DriverStation.Alliance;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class Vision extends SubsystemBase {
 
@@ -89,7 +81,6 @@ public class Vision extends SubsystemBase {
 
     private final VisionIO.VisionIOInputs[] inputs = new VisionIO.VisionIOInputs[] { new VisionIO.VisionIOInputs(),
             new VisionIO.VisionIOInputs() };
-    private final String[] camNames = new String[] { VisionConstants.LIMELIGHT1_NAME, VisionConstants.LIMELIGHT2_NAME };
 
     public void setUseVision(boolean usevision) {
         this.useVision = usevision;

--- a/src/main/java/frc/robot/subsystems/Vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/Vision/Vision.java
@@ -127,7 +127,7 @@ public class Vision extends SubsystemBase {
 
         for (int i = 0; i < io.length; i++) {
             // update the inputs from the netwrork tables named camNames[i]
-            io[i].updateInputs(inputs[i], camNames[i], gyroangle.get().getDegrees());
+            io[i].updateInputs(inputs[i], gyroangle.get().getDegrees());
             // keeps the pipeline always the same
             io[i].setPipeline(pipeline, camNames[i]);
         }

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
@@ -68,9 +68,6 @@ public interface VisionIO {
     default void updateInputs(VisionIOInputs inputs, String CamName, double gyroAngle) {}
 
     /** Enabled or disabled vision LEDs. */
-    default void setLEDs(LED led, String CamName) {}
-
-    /** Enabled or disabled vision LEDs. */
     default void setCameraModes(CameraMode mode, String CamName) {}
 
     /** Sets the pipeline number. */

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
@@ -21,7 +21,6 @@ public interface VisionIO {
      * Mid: has slightly higher FPS, but allows for farther vision updates when halfway down the field
      * Close: has the highest FPS, but only has limited range
      */
-
     
     enum Pipelines {
         Test(0);

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
@@ -68,7 +68,7 @@ public interface VisionIO {
     default void updateInputs(VisionIOInputs inputs, double gyroAngle) {}
 
     /** Enabled or disabled vision LEDs. */
-    default void setCameraModes(CameraMode mode, String CamName) {}
+    default void setCameraModes(CameraMode mode) {}
 
     /** Sets the pipeline number. */
     default void setPipeline(Pipelines pipeline, String CamName) {}

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
@@ -71,6 +71,6 @@ public interface VisionIO {
     default void setCameraModes(CameraMode mode) {}
 
     /** Sets the pipeline number. */
-    default void setPipeline(Pipelines pipeline, String CamName) {}
+    default void setPipeline(Pipelines pipeline) {}
 
 }

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIO.java
@@ -65,7 +65,7 @@ public interface VisionIO {
     }
 
     /** Updates the set of loggable inputs. */
-    default void updateInputs(VisionIOInputs inputs, String CamName, double gyroAngle) {}
+    default void updateInputs(VisionIOInputs inputs, double gyroAngle) {}
 
     /** Enabled or disabled vision LEDs. */
     default void setCameraModes(CameraMode mode, String CamName) {}

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
@@ -1,14 +1,8 @@
 package frc.robot.subsystems.Vision;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.lib.util.LimelightHelpers;
 import frc.robot.lib.util.LimelightHelpers.PoseEstimate;
 import frc.robot.lib.util.LimelightHelpers.RawFiducial;
@@ -25,7 +19,6 @@ public class VisionIOLimelight implements VisionIO {
     }
 
     // Uses limelight lib and network tables to get the values from the limelight
-    // TODO: Use getBotPoseEstimate() from LimelightHelpers
     @Override
     public void updateInputs(VisionIOInputs inputs, double gyroAngle) {
         LimelightHelpers.SetRobotOrientation(cameraName, gyroAngle, 0, 0, 0, 0, 0 );
@@ -54,6 +47,7 @@ public class VisionIOLimelight implements VisionIO {
             tagIDDs[i] = fiducials[i].id;
             tagDistances[i] = fiducials[i].distToRobot;
         }
+        
         inputs.tagIDs = tagIDDs;
         inputs.tagDistances = tagDistances;
 

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
@@ -16,18 +16,21 @@ import edu.wpi.first.wpilibj.Timer;
 
 public class VisionIOLimelight implements VisionIO {
 
-    public VisionIOLimelight(String CamName) {
-        setLEDs(LED.OFF, CamName);
-        setPipeline(Pipelines.Test, CamName);
+    private final String cameraName;
+
+    public VisionIOLimelight(String cameraName) {
+        this.cameraName = cameraName;
+        setLEDs(LED.OFF, cameraName);
+        setPipeline(Pipelines.Test, cameraName);
     }
 
     // Uses limelight lib and network tables to get the values from the limelight
     // TODO: Use getBotPoseEstimate() from LimelightHelpers
     @Override
-    public void updateInputs(VisionIOInputs inputs, String limelightName, double gyroAngle) {
-        LimelightHelpers.SetRobotOrientation(limelightName, gyroAngle, 0, 0, 0, 0, 0 );
+    public void updateInputs(VisionIOInputs inputs, double gyroAngle) {
+        LimelightHelpers.SetRobotOrientation(cameraName, gyroAngle, 0, 0, 0, 0, 0 );
         // Gets the needed data from the networktables
-        PoseEstimate botPoseEstimate = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(limelightName);
+        PoseEstimate botPoseEstimate = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(cameraName);
 
         // Latency (Pipeline + Capture)
         double latency = botPoseEstimate.latency;
@@ -55,12 +58,12 @@ public class VisionIOLimelight implements VisionIO {
         inputs.tagDistances = tagDistances;
 
         // Direct access to the network tables for other values
-        final NetworkTable limelight = LimelightHelpers.getLimelightNTTable(limelightName);
+        final NetworkTable limelight = LimelightHelpers.getLimelightNTTable(cameraName);
         // connected if heartbeat value is not zero
         NetworkTableEntry heartbeatEntry = limelight.getEntry("hb");
         inputs.connected = heartbeatEntry.getDouble(0.0) > 0.0;
         // has target if true
-        inputs.hasTarget = LimelightHelpers.getTV(limelightName);
+        inputs.hasTarget = LimelightHelpers.getTV(cameraName);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
@@ -21,7 +21,7 @@ public class VisionIOLimelight implements VisionIO {
     public VisionIOLimelight(String cameraName) {
         this.cameraName = cameraName;
         setLEDs(LED.OFF, cameraName);
-        setPipeline(Pipelines.Test, cameraName);
+        setPipeline(Pipelines.Test);
     }
 
     // Uses limelight lib and network tables to get the values from the limelight
@@ -67,8 +67,8 @@ public class VisionIOLimelight implements VisionIO {
     }
 
     @Override
-    public void setPipeline(Pipelines pipeline, String limelightName) {
-        NetworkTable limelight = LimelightHelpers.getLimelightNTTable(limelightName);
+    public void setPipeline(Pipelines pipeline) {
+        NetworkTable limelight = LimelightHelpers.getLimelightNTTable(cameraName);
         limelight.getEntry("pipeline").setDouble(pipeline.getNum());
     }
 

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
@@ -75,8 +75,7 @@ public class VisionIOLimelight implements VisionIO {
         limelight.getEntry("camMode").setDouble(camera.getNum());
     }
 
-    @Override
-    public void setLEDs(LED led, String limelightName) {
+    private void setLEDs(LED led, String limelightName) {
         final NetworkTable limelight = LimelightHelpers.getLimelightNTTable(limelightName);
         limelight.getEntry("ledMode").setDouble(led.getNum());
     }

--- a/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionIOLimelight.java
@@ -73,8 +73,8 @@ public class VisionIOLimelight implements VisionIO {
     }
 
     @Override
-    public void setCameraModes(CameraMode camera, String limelightName) {
-        final NetworkTable limelight = LimelightHelpers.getLimelightNTTable(limelightName);
+    public void setCameraModes(CameraMode camera) {
+        final NetworkTable limelight = LimelightHelpers.getLimelightNTTable(cameraName);
         limelight.getEntry("camMode").setDouble(camera.getNum());
     }
 


### PR DESCRIPTION
Cleaned up unused variables and imports.
Moved "cameraname" parameter from VisionIO methods and moved to the VisionIOLimelight class.