### PR TITLE
Change BoolSupplier array to separate supplier interface

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -43,7 +43,6 @@ public class RobotContainer {
       new CommandXboxController(OperatorConstants.DRIVER_CONTROLLER_PORT);
   private final Joystick buttonBoardController =
       new Joystick(OperatorConstants.BUTTON_BOARD_PORT);
-  private final BooleanSupplier[] buttonSupplier = new BooleanSupplier[9];
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -54,11 +53,7 @@ public class RobotContainer {
     ObjectiveSelecterIONetworkTables objectiveSelecterIOImpl = new ObjectiveSelecterIONetworkTables();
     objectiveTracker = new ObjectiveTracker(objectiveSelecterIOImpl);
 
-    for (int i = 1; i <= 9; i++) {
-      final int index = i;
-      buttonSupplier[index] = () -> buttonBoardController.getRawButton(index);
-    }
-    buttonBoard = new ButtonBoard(buttonSupplier);
+    buttonBoard = new ButtonBoard((int i) -> buttonBoardController.getRawButton(i));
 
     SmartDashboard.putNumber("speed", 0.25);
     // Configure the trigger bindings

--- a/src/main/java/frc/robot/subsystems/objectiveTracker/ButtonBoard.java
+++ b/src/main/java/frc/robot/subsystems/objectiveTracker/ButtonBoard.java
@@ -9,47 +9,48 @@ import java.util.function.BooleanSupplier;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class ButtonBoard extends SubsystemBase {
-  private BooleanSupplier[] buttonSupplier;
-  private boolean[] buttons;
+  
+  public interface ButtonSupplier {
+    boolean getButtonState(int buttonNumber);
+  }
+
+  private ButtonSupplier buttonSupplier;
   private int level = 1;
   private boolean rightSide = false;
   private int reefSide = 0;
+
   /** Creates a new ButtonBoard. */
-  public ButtonBoard(BooleanSupplier[] buttonSupplier) {
+  public ButtonBoard(ButtonSupplier buttonSupplier) {
     this.buttonSupplier = buttonSupplier;
   }
 
   @Override
   public void periodic() {
-    for(int i = 0; i < buttonSupplier.length; i++) {
-      buttons[i] = buttonSupplier[i].getAsBoolean();
-    }
-
-    if(buttons[5]) {
+    if(buttonSupplier.getButtonState(5)) {
       level = 4;
     }
 
-    else if(buttons[6]) {
+    else if(buttonSupplier.getButtonState(6)) {
       level = 3;
     }
 
-    else if(buttons[7]) {
+    else if(buttonSupplier.getButtonState(7)) {
       level = 2;
     }
 
-    else if(buttons[8]) {
+    else if(buttonSupplier.getButtonState(8)) {
       level = 1;
     }
 
-    if(buttons[1]) {
+    if(buttonSupplier.getButtonState(1)) {
       rightSide = true;
     }
 
-    else if(buttons[2]) {
+    else if(buttonSupplier.getButtonState(2)) {
       rightSide = false;
     }
     
-    if(buttons[3]) {
+    if(buttonSupplier.getButtonState(3)) {
       if(reefSide == 5) {
         reefSide = 0;
       } else {
@@ -57,7 +58,7 @@ public class ButtonBoard extends SubsystemBase {
       }
     }
 
-    else if(buttons[4]) {
+    else if(buttonSupplier.getButtonState(4)) {
       if(reefSide == 0) {
         reefSide = 5;
       } else {


### PR DESCRIPTION
Keeping an array of boolean suppliers is a little cumbersome to set up and could potentially cause maintenance issues in the future.  This PR shows an example of using a custom supplier instead.