### PR TITLE
Make swerve drive compatible with the local simulator

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -6,6 +6,9 @@ package frc.robot;
 
 import edu.wpi.first.epilogue.Epilogue;
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.net.PortForwarder;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -116,7 +119,10 @@ public class Robot extends TimedRobot {
 
   /** This function is called once when the robot is first started up. */
   @Override
-  public void simulationInit() {}
+  public void simulationInit() {
+    // Set an initial position so the robot is on the field to start.
+    robotContainer.setInitialRobotPose(new Pose2d(new Translation2d(2,2), Rotation2d.fromDegrees((0))));
+  }
 
   /** This function is called periodically whilst in simulation. */
   @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,6 +12,7 @@ import frc.robot.subsystems.Intake;
 import java.io.File;
 
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -99,5 +100,9 @@ public class RobotContainer {
   public Command getAutonomousCommand() {
     // An example command will be run in autonomous
     return new Command() {};
+  }
+
+  public void setInitialRobotPose(Pose2d pose) {
+    swerve.setPose(pose);
   }
 }

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -49,19 +49,18 @@ import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 
 public class Swerve extends SubsystemBase {
 
-  private final SwerveDrive swerveDrive;
-  public double maximumSpeed = SwerveConstants.SWERVE_MAXIMUM_VELOCITY;
-  public double maximumAngularSpeed = SwerveConstants.SWERVE_MAXIMUM_ANGULAR_VELOCITY;
-  private Rotation2d currentTargetAngle = new Rotation2d();
-  private Pose2d allianceRelPose = new Pose2d();
-  private boolean hadbadreading;
+    private final SwerveDrive swerveDrive;
+    public double maximumSpeed = SwerveConstants.SWERVE_MAXIMUM_VELOCITY;
+    public double maximumAngularSpeed = SwerveConstants.SWERVE_MAXIMUM_ANGULAR_VELOCITY;
+    private Rotation2d currentTargetAngle = new Rotation2d();
+    private boolean hadbadreading;
 
-  /** Creates a new Swerve. */
-  public Swerve(File config_dir) {
+    /** Creates a new Swerve. */
+    public Swerve(File config_dir) {
 
         // Configure the Telemetry before creating the SwerveDrive to avoid unnecessary
         // objects being created.
-        SwerveDriveTelemetry.verbosity = TelemetryVerbosity.INFO;
+        SwerveDriveTelemetry.verbosity = TelemetryVerbosity.POSE;
         try {
             swerveDrive = new SwerveParser(config_dir).createSwerveDrive(maximumSpeed);
             // Alternative method if you don't want to supply the conversion factor via JSON
@@ -75,82 +74,87 @@ public class Swerve extends SubsystemBase {
                                                  // via angle.
         // swerveDrive.chassisVelocityCorrection = false;
 
-            for(int i = 0; i < swerveDrive.getModules().length; i++) {
+        for (int i = 0; i < swerveDrive.getModules().length; i++) {
             // Lower the kS to reduce wobble?
-            // swerveDrive.getModules()[i].setFeedforward(new SimpleMotorFeedforward(SwerveConstants.MODULE_CONSTANTS[i].drive_kS * 0.1, SwerveConstants.MODULE_CONSTANTS[i].drive_kV, SwerveConstants.MODULE_CONSTANTS[i].drive_kA));
-          }
+            // swerveDrive.getModules()[i].setFeedforward(new
+            // SimpleMotorFeedforward(SwerveConstants.MODULE_CONSTANTS[i].drive_kS * 0.1,
+            // SwerveConstants.MODULE_CONSTANTS[i].drive_kV,
+            // SwerveConstants.MODULE_CONSTANTS[i].drive_kA));
+        }
         // setupPathPlanner();
-  }
+    }
 
-        /**
+    /**
      * Setup AutoBuilder for PathPlanner.
      */
-/*    public void setupPathPlanner() {
-      AutoBuilder.configureHolonomic(
-              swerveDrive::getPose, // Robot pose supplier
-              swerveDrive::resetOdometry, // Method to reset odometry (will be called if your auto has a starting pose)
-              swerveDrive::getRobotVelocity, // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
-              swerveDrive::drive, // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds
-              new HolonomicPathFollowerConfig( // HolonomicPathFollowerConfig, this should likely live in your
-                                               // Constants class
-                      new PIDConstants(0.65, 0.0, 0.0),
-                      // Translation PID constants
-                      new PIDConstants(2,
-                              0,
-                              0.05), // TODO: TUNE THIS, NOT SURE IF SHOULD BE 0.005 PER OLD COMMENT
-                      // Rotation PID constants
-                      4.5,
-                      // Max module speed, in m/s
-                      swerveDrive.swerveDriveConfiguration.getDriveBaseRadiusMeters(),
-                      // Drive base radius in meters. Distance from robot center to furthest module.
-                      new ReplanningConfig()
-              // Default path replanning config. See the API for the options here
-              ),
-              () -> {
-                  // Boolean supplier that controls when the path will be mirrored for the red
-                  // alliance
-                  // This will flip the path being followed to the red side of the field.
-                  // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
-                  var alliance = DriverStation.getAlliance();
-                  return alliance.isPresent() && (alliance.get() == DriverStation.Alliance.Red);
-              },
-              this // Reference to this subsystem to set requirements
-      );
-  
+    /*
+     * public void setupPathPlanner() {
+     * AutoBuilder.configureHolonomic(
+     * swerveDrive::getPose, // Robot pose supplier
+     * swerveDrive::resetOdometry, // Method to reset odometry (will be called if
+     * your auto has a starting pose)
+     * swerveDrive::getRobotVelocity, // ChassisSpeeds supplier. MUST BE ROBOT
+     * RELATIVE
+     * swerveDrive::drive, // Method that will drive the robot given ROBOT RELATIVE
+     * ChassisSpeeds
+     * new HolonomicPathFollowerConfig( // HolonomicPathFollowerConfig, this should
+     * likely live in your
+     * // Constants class
+     * new PIDConstants(0.65, 0.0, 0.0),
+     * // Translation PID constants
+     * new PIDConstants(2,
+     * 0,
+     * 0.05), // TODO: TUNE THIS, NOT SURE IF SHOULD BE 0.005 PER OLD COMMENT
+     * // Rotation PID constants
+     * 4.5,
+     * // Max module speed, in m/s
+     * swerveDrive.swerveDriveConfiguration.getDriveBaseRadiusMeters(),
+     * // Drive base radius in meters. Distance from robot center to furthest
+     * module.
+     * new ReplanningConfig()
+     * // Default path replanning config. See the API for the options here
+     * ),
+     * () -> {
+     * // Boolean supplier that controls when the path will be mirrored for the red
+     * // alliance
+     * // This will flip the path being followed to the red side of the field.
+     * // THE ORIGIN WILL REMAIN ON THE BLUE SIDE
+     * var alliance = DriverStation.getAlliance();
+     * return alliance.isPresent() && (alliance.get() ==
+     * DriverStation.Alliance.Red);
+     * },
+     * this // Reference to this subsystem to set requirements
+     * );
+     * 
+     * 
+     * }
+     */
 
-  }
-*/
-
-  /** Gets the current alliance, defaulting to blue */
+    /** Gets the current alliance, defaulting to blue */
     public Alliance getAllianceDefaultBlue() {
         Alliance currentAlliance;
         if (DriverStation.getAlliance().isPresent()) {
-          currentAlliance = DriverStation.getAlliance().get();
+            currentAlliance = DriverStation.getAlliance().get();
         } else {
-          currentAlliance = Alliance.Blue;
-          System.out.println("No alliance, setting to blue");
+            currentAlliance = Alliance.Blue;
+            System.out.println("No alliance, setting to blue");
         }
         return currentAlliance;
-      }
+    }
 
-      /** Uses the current field rel pose to get the alliance rel pose, should be called periodically */
-    public void updateAllianceRelPose() {
-      Pose2d fieldRelPose = swerveDrive.getPose();
-      allianceRelPose = alliancePoseFlipper(fieldRelPose);
-  }
-
-  /** Flips a Pose2d by 180 degrees if necessary */
+    /** Flips a Pose2d by 180 degrees if necessary */
     public Pose2d alliancePoseFlipper(Pose2d input) {
-        if(getAllianceDefaultBlue() == Alliance.Blue) {
+        if (getAllianceDefaultBlue() == Alliance.Blue) {
             return input;
         } else {
-            return new Pose2d(FieldConstants.fieldLength - input.getX(), FieldConstants.fieldWidth - input.getY(), input.getRotation().minus(new Rotation2d(Math.PI)));
+            return new Pose2d(FieldConstants.fieldLength - input.getX(), FieldConstants.fieldWidth - input.getY(),
+                    input.getRotation().minus(new Rotation2d(Math.PI)));
         }
     }
 
-    /** Takes a chassis speeds object and flips it 180 degrees if needed*/
+    /** Takes a chassis speeds object and flips it 180 degrees if needed */
     public ChassisSpeeds allianceTargetSpeedsFlipper(ChassisSpeeds input) {
-        if(getAllianceDefaultBlue() == Alliance.Blue) {
+        if (getAllianceDefaultBlue() == Alliance.Blue) {
             return input;
         } else {
             return new ChassisSpeeds(-input.vxMetersPerSecond, -input.vyMetersPerSecond, input.omegaRadiansPerSecond);
@@ -159,40 +163,53 @@ public class Swerve extends SubsystemBase {
 
     /** Takes a rotation2d and flips it 180 degrees */
     public Rotation2d allianceRotationFlipper(Rotation2d input) {
-      return getAllianceDefaultBlue() == Alliance.Blue ? input : input.minus(new Rotation2d(Math.PI));
-  }
+        return getAllianceDefaultBlue() == Alliance.Blue ? input : input.minus(new Rotation2d(Math.PI));
+    }
 
-  /** Gets current pose, alliance relative */
-  public Pose2d getAllianceRelPose() {
-      return allianceRelPose;
-  }
-
-    /** Drive robot with alliance relative speeds.
-     *  Converts them to field relative speeds first then drives the robot.
-     *  If using heading drive, it does not use the target angle at all.
-    */
+    /**
+     * Drive robot with alliance relative speeds.
+     * Converts them to field relative speeds first then drives the robot.
+     * If using heading drive, it does not use the target angle at all.
+     */
     public void driveAllianceRelative(double x, double y, double rotationRate, boolean headingDrive) {
         if (headingDrive) {
-            swerveDrive.driveFieldOriented(swerveDrive.swerveController.getTargetSpeeds(getAllianceDefaultBlue() == Alliance.Blue ? x : -x, getAllianceDefaultBlue() == Alliance.Blue ? y : -y,
-                    currentTargetAngle.getRadians(), swerveDrive.getYaw().getRadians(), maximumSpeed));
+            swerveDrive.driveFieldOriented(
+                    swerveDrive.swerveController.getTargetSpeeds(getAllianceDefaultBlue() == Alliance.Blue ? x : -x,
+                            getAllianceDefaultBlue() == Alliance.Blue ? y : -y,
+                            currentTargetAngle.getRadians(), swerveDrive.getYaw().getRadians(), maximumSpeed));
         } else {
-            swerveDrive.drive(new Translation2d(getAllianceDefaultBlue() == Alliance.Blue ? x : -x, getAllianceDefaultBlue() == Alliance.Blue ? y : -y),
+            swerveDrive.drive(
+                    new Translation2d(getAllianceDefaultBlue() == Alliance.Blue ? x : -x,
+                            getAllianceDefaultBlue() == Alliance.Blue ? y : -y),
                     rotationRate, true, false);
         }
     }
-    
+
     /**
      * Resets the gyro angle to zero and resets odometry to the same position, but
      * facing toward 0. (Alliance Relative)
      */
     public void zeroGyro() {
-      setGyroAngle(allianceRotationFlipper(new Rotation2d()));
-      currentTargetAngle = allianceRotationFlipper(new Rotation2d());
-      swerveDrive.resetOdometry(new Pose2d(swerveDrive.getPose().getTranslation(), allianceRotationFlipper(new Rotation2d())));
-  }
+        setGyroAngle(allianceRotationFlipper(new Rotation2d()));
+        currentTargetAngle = allianceRotationFlipper(new Rotation2d());
+        swerveDrive.resetOdometry(
+                new Pose2d(swerveDrive.getPose().getTranslation(), allianceRotationFlipper(new Rotation2d())));
+    }
 
-  /**
-     * Sets the current angle of the gyro (Field Relative). If the robot reaches the same angle, the
+    /**
+     * Sets the current robot pose.
+     * This should not typically be called -- it is exposed to allow the robot
+     * to be set to a valid position on the field when starting a simulation.
+     * 
+     * @param pose The current robot pose.
+     */
+    public void setPose(Pose2d pose) {
+        swerveDrive.resetOdometry(pose);
+    }
+
+    /**
+     * Sets the current angle of the gyro (Field Relative). If the robot reaches the
+     * same angle, the
      * gyro will report this angle.
      * 
      * @param currentAngle The angle that the gyro should read in its current state.
@@ -202,24 +219,25 @@ public class Swerve extends SubsystemBase {
     }
 
     public double getAngularVelocityRad_Sec() {
-      return swerveDrive.getRobotVelocity().omegaRadiansPerSecond;
-  }
+        return swerveDrive.getRobotVelocity().omegaRadiansPerSecond;
+    }
 
     public Rotation2d getCurrentTargetAngle() {
-      return currentTargetAngle;
-  }
+        return currentTargetAngle;
+    }
 
-  public void setTargetAngle(Rotation2d newTargetAngle) {
-      currentTargetAngle = newTargetAngle;
-  }
+    public void setTargetAngle(Rotation2d newTargetAngle) {
+        currentTargetAngle = newTargetAngle;
+    }
 
-  public void setTargetAllianceRelAngle(Rotation2d allianceRelAngle) {
-      currentTargetAngle = allianceRotationFlipper(allianceRelAngle);
-  }
+    public void setTargetAllianceRelAngle(Rotation2d allianceRelAngle) {
+        currentTargetAngle = allianceRotationFlipper(allianceRelAngle);
+    }
 
-  /**
+    /**
      * <h2>More features</h2>
      * Drives alliance relative
+     * 
      * @param translationX      Translation input in the X direction.
      * @param translationY      Translation input in the Y direction.
      * @param rotationX         Rotation input in the X direction.
@@ -244,7 +262,8 @@ public class Swerve extends SubsystemBase {
             double yInput = scaledDeadbandTranslationInputs[1];
             // determining if target angle is commanded
             if (deadbandRotationInputs[0] != 0 || deadbandRotationInputs[1] != 0) {
-                setTargetAllianceRelAngle(Rotation2d.fromRadians(Math.atan2(deadbandRotationInputs[1], deadbandRotationInputs[0])));
+                setTargetAllianceRelAngle(
+                        Rotation2d.fromRadians(Math.atan2(deadbandRotationInputs[1], deadbandRotationInputs[0])));
             }
             if (leftRotationInput != 0 && rightRotationInput == 0) {
                 swerveDrive.setHeadingCorrection(false);
@@ -298,8 +317,11 @@ public class Swerve extends SubsystemBase {
             swerveDrive.resetOdometry(new Pose2d(0.0, 0.0, swerveDrive.getYaw()));
         }
 
-        // Add Vision Measurement if it passes the checks, but without taking into account vision yaw.
-        swerveDrive.addVisionMeasurement(new Pose2d(visionData.visionPose().getTranslation(), swerveDrive.getOdometryHeading()), visionData.time(),
+        // Add Vision Measurement if it passes the checks, but without taking into
+        // account vision yaw.
+        swerveDrive.addVisionMeasurement(
+                new Pose2d(visionData.visionPose().getTranslation(), swerveDrive.getOdometryHeading()),
+                visionData.time(),
                 visionData.visionReliability());
         Pose2d newPose = swerveDrive.getPose();
         if (Double.isNaN(newPose.getX()) || Double.isNaN(newPose.getY())) {
@@ -328,7 +350,8 @@ public class Swerve extends SubsystemBase {
             setTargetAngle(desired_heading);
         });
     }
-        /**
+
+    /**
      * <h2>Vision Targeting</h2>
      * Drives field oriented with translation X, Y, and points at the given target
      * point
@@ -358,34 +381,33 @@ public class Swerve extends SubsystemBase {
         });
     }
 
-      /**
-   * Command to characterize the robot drive motors using SysId
-   *
-   * @return SysId Drive Command
-   */
-  public Command sysIdDriveMotorCommand()
-  {
-    return SwerveDriveTest.generateSysIdCommand(
-        SwerveDriveTest.setDriveSysIdRoutine(
-            new Config(),
-            this, swerveDrive, 12, false),
-        3.0, 5.0, 3.0); // TODO: Tweak (increase quasitimeout if possible) for running sysid characterization
-  }
+    /**
+     * Command to characterize the robot drive motors using SysId
+     *
+     * @return SysId Drive Command
+     */
+    public Command sysIdDriveMotorCommand() {
+        return SwerveDriveTest.generateSysIdCommand(
+                SwerveDriveTest.setDriveSysIdRoutine(
+                        new Config(),
+                        this, swerveDrive, 12, false),
+                3.0, 5.0, 3.0); // TODO: Tweak (increase quasitimeout if possible) for running sysid
+                                // characterization
+    }
 
-  /**
-   * Command to characterize the robot angle motors using SysId
-   *
-   * @return SysId Angle Command
-   */
-  public Command sysIdAngleMotorCommand()
-  {
-    return SwerveDriveTest.generateSysIdCommand(
-        SwerveDriveTest.setAngleSysIdRoutine(
-            new Config(),
-            this, swerveDrive),
-        3.0, 5.0, 3.0); // TODO: Tweak (increase quasitimeout if possible) if needed for running sysid characterization
-  }
-
+    /**
+     * Command to characterize the robot angle motors using SysId
+     *
+     * @return SysId Angle Command
+     */
+    public Command sysIdAngleMotorCommand() {
+        return SwerveDriveTest.generateSysIdCommand(
+                SwerveDriveTest.setAngleSysIdRoutine(
+                        new Config(),
+                        this, swerveDrive),
+                3.0, 5.0, 3.0); // TODO: Tweak (increase quasitimeout if possible) if needed for running sysid
+                                // characterization
+    }
 
     public boolean isvisionOk() {
         return !hadbadreading;
@@ -398,15 +420,18 @@ public class Swerve extends SubsystemBase {
         swerveDrive.addVisionMeasurement(new Pose2d(3, 3, Rotation2d.fromDegrees(65)), Timer.getFPGATimestamp());
     }
 
-    /** 
-     * Set the hardware zero point of the angle motor's absolute encoder to the current position.
-     * The 45 + 90n degree angle offsets are in software, on top of this. 
-     * */
+    /**
+     * Set the hardware zero point of the angle motor's absolute encoder to the
+     * current position.
+     * The 45 + 90n degree angle offsets are in software, on top of this.
+     */
     public void zeroSwerveOffsets() {
         for (SwerveModule module : swerveDrive.getModules()) {
             // double position = module.getRawAbsolutePosition();
-            // double encoderOffset = ((SparkMax) module.configuration.angleMotor.getMotor()).configAccessor.absoluteEncoder.getZeroOffset();
-            // module.configuration.absoluteEncoder.setAbsoluteEncoderOffset(MathUtil.inputModulus((encoderOffset + position) / 360, 0, 1));
+            // double encoderOffset = ((SparkMax)
+            // module.configuration.angleMotor.getMotor()).configAccessor.absoluteEncoder.getZeroOffset();
+            // module.configuration.absoluteEncoder.setAbsoluteEncoderOffset(MathUtil.inputModulus((encoderOffset
+            // + position) / 360, 0, 1));
             module.configuration.absoluteEncoder.setAbsoluteEncoderOffset(0);
             System.out.println("absolute position:" + module.configuration.absoluteEncoder.getAbsolutePosition());
             System.out.println("raw ap:" + module.getRawAbsolutePosition());
@@ -426,37 +451,38 @@ public class Swerve extends SubsystemBase {
             angleMotors[i] = (SparkMax) swerveDrive.getModules()[i].getAngleMotor().getMotor();
             angleOffsets[i] = angleMotors[i].configAccessor.absoluteEncoder.getZeroOffset() * 360;
             currentOffsets[i] = Rotation2d.fromDegrees(angleOffsets[i]);
-            
+
             encoders[i] = (SparkAbsoluteEncoder) swerveDrive.getModules()[i].getAbsoluteEncoder().getAbsoluteEncoder();
             measuredPositions[i] = Rotation2d.fromDegrees(encoders[i].getPosition());
-            newOffsets[i] = new Rotation2d().plus(currentOffsets[i]).plus(measuredPositions[i]).plus(Rotation2d.fromDegrees(getAngleForModule(i)));
-            moduleConfigs[i].absoluteEncoder.setAbsoluteEncoderOffset(MathUtil.inputModulus(newOffsets[i].getDegrees() / 360, 0, 1));
+            newOffsets[i] = new Rotation2d().plus(currentOffsets[i]).plus(measuredPositions[i])
+                    .plus(Rotation2d.fromDegrees(getAngleForModule(i)));
+            moduleConfigs[i].absoluteEncoder
+                    .setAbsoluteEncoderOffset(MathUtil.inputModulus(newOffsets[i].getDegrees() / 360, 0, 1));
             System.out.println("Module " + i + " offset: " + newOffsets[i].getDegrees());
-            System.out.println(currentOffsets[i].getDegrees() + " + " + measuredPositions[i].getDegrees() + " = " + newOffsets[i].getDegrees());
+            System.out.println(currentOffsets[i].getDegrees() + " + " + measuredPositions[i].getDegrees() + " = "
+                    + newOffsets[i].getDegrees());
         }
     }
 
     private double getAngleForModule(int moduleNumber) {
-      return switch (moduleNumber) {
-          case 0 -> 225;
-          case 1 -> 315;
-          case 2 -> 135;
-          case 3 -> 45;
-          default -> throw new IllegalArgumentException("Invalid module number");
-      };
-  }
+        return switch (moduleNumber) {
+            case 0 -> 225;
+            case 1 -> 315;
+            case 2 -> 135;
+            case 3 -> 45;
+            default -> throw new IllegalArgumentException("Invalid module number");
+        };
+    }
 
-  public Command driveForward(double percentage) {
-    return run(() -> {
-        swerveDrive.drive(new Translation2d(percentage * maximumSpeed, 0), 0, false, false);
-    });
-  }
+    public Command driveForward(double percentage) {
+        return run(() -> {
+            swerveDrive.drive(new Translation2d(percentage * maximumSpeed, 0), 0, false, false);
+        });
+    }
 
-  @Override
-  public void periodic() {
-    // This method will be called once per scheduler run
-    
-    swerveDrive.updateOdometry();
-    updateAllianceRelPose();
-  }
+    @Override
+    public void periodic() {
+        // This method will be called once per scheduler run
+        swerveDrive.updateOdometry();
+    }
 }


### PR DESCRIPTION
Changed swerve drive telemetry to "POSE" to emit pose data.
Added a method to be able to set the initial pose to someplace inside the field on simulation init.
Fixed a bunch of formatting in the swerve subsystem.