### PR TITLE
Re-add visionDataConsumer

### DIFF
--- a/src/main/java/frc/robot/subsystems/Vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/Vision/Vision.java
@@ -190,9 +190,7 @@ public class Vision extends SubsystemBase {
             // Add vision data to swerve pose estimator
             VisionData visionData = new VisionData(visionCalcPose, inputs[i].captureTimestamp,
                 VecBuilder.fill(xyStdDev, xyStdDev, thetaStdDev));
-            // if(!DriverStation.isAutonomous()){ // Add to only allow vision data to be added in teleop
-            //     visionDataConsumer.accept(visionData);
-            // }
+                visionDataConsumer.accept(visionData);
 
             // Add robot pose from this camera to a list of all robot poses
             allRobotPoses.add(visionCalcPose);


### PR DESCRIPTION
Vision data was never added to pose estimation during RIT... whoops.